### PR TITLE
add MPICH install script

### DIFF
--- a/elements/mpich/element-deps
+++ b/elements/mpich/element-deps
@@ -1,0 +1,1 @@
+chameleon-common

--- a/elements/mpich/post-install.d/05-mpich
+++ b/elements/mpich/post-install.d/05-mpich
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#############################################################
+# Pre-Installation
+#############################################################
+
+MPICH_TMP_FOLDER=/root/tmp
+mkdir -p $MPICH_TMP_FOLDER
+
+# facter is used for hostfile generation in complex appliances
+yum install facter
+
+#############################################################
+# Installation
+#############################################################
+
+cd $MPICH_TMP_FOLDER
+
+# Get MPICH
+VER=4.2.1
+wget -nv https://www.mpich.org/static/downloads/${VER}/mpich-${VER}.tar.gz
+tar xvfz mpich-${VER}.tar.gz && cd mpich-${VER}
+
+# build and install MPICH
+./configure
+make -j
+make install
+
+# install cpi example
+cd examples
+mpicc -o /usr/local/bin/cpi cpi.c
+
+#############################################################
+# Cleaning
+#############################################################
+
+# Clean the tmp folder
+rm -rf $MPICH_TMP_FOLDER
+
+exit 0


### PR DESCRIPTION
Mostly a copy of the same script from https://github.com/ChameleonCloud/CC-CentOS7/blob/master/elements/mpich-3.3.1/post-install.d/05-mpich. Updated to use the latest MPICH 4.2.1 release.